### PR TITLE
Plugin restart patch

### DIFF
--- a/com.sahabatabadi.api/src/com/sahabatabadi/api/SASApiActivator.java
+++ b/com.sahabatabadi.api/src/com/sahabatabadi/api/SASApiActivator.java
@@ -35,13 +35,14 @@ public class SASApiActivator implements BundleActivator {
             log.info("SAS iDempiere API is starting");
         SASApiActivator.context = bundleContext;
 
-        LoginEmulator.emulateLogin();
-
         if (rmiServer == null) {
             rmiServer = new RMIService();
         }
 
         rmiServer.start();
+        
+        LoginEmulator.emulateLogin();
+        ThreadPoolManager.reinitialize();
     }
 
     /*

--- a/com.sahabatabadi.api/src/com/sahabatabadi/api/ThreadPoolManager.java
+++ b/com.sahabatabadi.api/src/com/sahabatabadi/api/ThreadPoolManager.java
@@ -29,7 +29,9 @@ public class ThreadPoolManager {
 
         ThreadPoolManager.executor = createExecutor();
 
-        oldExecutor.shutdown();
+        if (oldExecutor != null) {
+        	oldExecutor.shutdown();	
+        }
     }
 
     /**

--- a/com.sahabatabadi.api/src/com/sahabatabadi/api/rmi/IRemoteApi.java
+++ b/com.sahabatabadi.api/src/com/sahabatabadi/api/rmi/IRemoteApi.java
@@ -7,6 +7,7 @@ import com.sahabatabadi.api.salesorder.BizzySalesOrder;
 
 public interface IRemoteApi extends Remote {
     public static final String BINDING_NAME = "SASiDempiereRemoteApi";
+	public static final int RMI_REGISTRY_PORT = 11579;
     
 	public String injectSo(BizzySalesOrder bizzySo) throws RemoteException;  
 }

--- a/com.sahabatabadi.api/src/com/sahabatabadi/api/rmi/RMIService.java
+++ b/com.sahabatabadi.api/src/com/sahabatabadi/api/rmi/RMIService.java
@@ -11,8 +11,6 @@ import java.util.logging.Level;
 import org.compiere.util.CLogger;
 
 public class RMIService {
-    public static final int RMI_REGISTRY_PORT = 1579;
-    
     private RemoteApi server;
     private Remote stub;
     private Registry registry;
@@ -28,7 +26,7 @@ public class RMIService {
             stub = (Remote) UnicastRemoteObject.exportObject(server, 0);
 
             // Bind the remote object's stub in the registry
-            registry = LocateRegistry.createRegistry(RMI_REGISTRY_PORT);
+            registry = LocateRegistry.createRegistry(IRemoteApi.RMI_REGISTRY_PORT);
             registry.rebind(IRemoteApi.BINDING_NAME, stub);
 
             if (log.isLoggable(Level.INFO))
@@ -46,6 +44,7 @@ public class RMIService {
             log.info("Stopping RMI registry service");
         try {
             registry.unbind(IRemoteApi.BINDING_NAME);
+            UnicastRemoteObject.unexportObject(registry, true);
         } catch (RemoteException | NotBoundException e) {
             if (log.isLoggable(Level.WARNING)) {
                 log.warning("RMI server exception: " + e.toString());


### PR DESCRIPTION
Patch 1: RMI
Unexported old RMI registry so a new registry can be created on restart.

Patch 2: ThreadPoolManager/ExecutorService
Added ThreadPoolManager re-initialization code so can inject new SO on restart.